### PR TITLE
Bug/#4 - Mask indexing issues and small fixes

### DIFF
--- a/include/itkDescoteauxEigenToScalarImageFilter.h
+++ b/include/itkDescoteauxEigenToScalarImageFilter.h
@@ -62,8 +62,12 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(DescoteauxEigenToScalarImageFilter, EigenToScalarImageFilter);
 
-  /** Mask related typedefs. */
-  typedef typename TMaskImage::PixelType    MaskPixelType;
+  /** Useful template typedefs. */
+  typedef typename TInputImage::Pointer       InputImagePointer;
+  typedef typename TInputImage::ConstPointer  InputImageConstPointer;
+  typedef typename TMaskImage::Pointer        MaskImagePointer;
+  typedef typename TMaskImage::ConstPointer   MaskImageConstPointer;
+  typedef typename TMaskImage::PixelType      MaskPixelType;
 
   /** Procesing filters */
   typedef DescoteauxEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >

--- a/include/itkDescoteauxEigenToScalarImageFilter.hxx
+++ b/include/itkDescoteauxEigenToScalarImageFilter.hxx
@@ -41,11 +41,16 @@ DescoteauxEigenToScalarImageFilter< TInputImage, TOutputImage, TMaskImage >
 ::GenerateInputRequestedRegion()
 {
   Superclass::GenerateInputRequestedRegion();
+
   if ( this->GetInput() )
   {
-  typename TInputImage::Pointer image =
-    const_cast< TInputImage * >( this->GetInput() );
-  image->SetRequestedRegionToLargestPossibleRegion();
+    InputImagePointer image = const_cast< typename Superclass::InputImageType * >( this->GetInput() );
+    image->SetRequestedRegionToLargestPossibleRegion();
+  }
+  if ( this->GetMaskImage() )
+  {
+    MaskImagePointer mask = const_cast< TMaskImage * >( this->GetMaskImage() );
+    mask->SetRequestedRegionToLargestPossibleRegion();
   }
 }
 

--- a/include/itkDescoteauxEigenToScalarImageFilter.hxx
+++ b/include/itkDescoteauxEigenToScalarImageFilter.hxx
@@ -63,10 +63,9 @@ void
 DescoteauxEigenToScalarImageFilter< TInputImage, TOutputImage, TMaskImage >
 ::GenerateData()
 {
-  /* Get input */
-  typename TInputImage::Pointer input = TInputImage::New();
-  input->Graft( const_cast< TInputImage * >( this->GetInput() ));
-
+  /* Get inputs */
+  InputImageConstPointer input = this->GetInput();
+  
   /* Connect filters */
   m_ParameterEstimationFilter->SetInput(input);
   m_UnaryFunctorFilter->SetInput(m_ParameterEstimationFilter->GetOutput());

--- a/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.h
+++ b/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.h
@@ -38,6 +38,11 @@ namespace itk {
  * Where the Frobenius norm for a real, symmetric matrix is given by
  * the square root of the sum of squares of the eigenvalues.
  * 
+ * If the input image and mask have different regions over which they
+ * are defined, parameters are estimated only in the intersection of
+ * the two image regions. However, the mask region must be a proper sub
+ * subset (contained) in the image region.
+ * 
  * \sa KrcahEigenToScalarImageFilter
  * 
  * \author: Bryce Besler

--- a/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.hxx
+++ b/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.hxx
@@ -143,11 +143,10 @@ DescoteauxEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
   RealType thisFrobeniusNorm;
 
   /* Get input pointer */
-  InputImagePointer inputPointer = const_cast< TInputImage * >( this->GetInput() );
+  InputImageConstPointer inputPointer = this->GetInput();
 
   /* Get mask pointer */
-  MaskImagePointer maskPointer = TMaskImage::New();
-  maskPointer = const_cast<TMaskImage*>(this->GetMaskImage());
+  MaskImageConstPointer maskPointer = this->GetMaskImage();
 
   /* Setup progress reporter */
   ProgressReporter progress( this, threadId, outputRegionForThread.GetNumberOfPixels() );

--- a/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.hxx
+++ b/include/itkDescoteauxEigenToScalarParameterEstimationImageFilter.hxx
@@ -62,11 +62,16 @@ DescoteauxEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
 ::GenerateInputRequestedRegion()
 {
   Superclass::GenerateInputRequestedRegion();
+
   if ( this->GetInput() )
   {
-  InputImagePointer image =
-    const_cast< typename Superclass::InputImageType * >( this->GetInput() );
-  image->SetRequestedRegionToLargestPossibleRegion();
+    InputImagePointer image = const_cast< typename Superclass::InputImageType * >( this->GetInput() );
+    image->SetRequestedRegionToLargestPossibleRegion();
+  }
+  if ( this->GetMaskImage() )
+  {
+    MaskImagePointer mask = const_cast< TMaskImage * >( this->GetMaskImage() );
+    mask->SetRequestedRegionToLargestPossibleRegion();
   }
 }
 
@@ -132,12 +137,6 @@ DescoteauxEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
 ::ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
                        ThreadIdType threadId)
 {
-  const SizeValueType size0 = outputRegionForThread.GetSize(0);
-  if (size0 == 0)
-  {
-    return;
-  }
-
   /* Count starts zero */
   RealType maxFrobeniusNorm = NumericTraits< RealType >::ZeroValue();
   RealType thisFrobeniusNorm;
@@ -148,11 +147,29 @@ DescoteauxEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
   /* Get mask pointer */
   MaskImageConstPointer maskPointer = this->GetMaskImage();
 
+  /* If we have a mask pointer we need to crop outputRegionForThread to the mask region */
+  InputRegionType croppedRegion = outputRegionForThread;
+  if (maskPointer) {
+    croppedRegion.Crop( maskPointer->GetLargestPossibleRegion() );
+    /* No check for one region being inside the other. Superclass::GenerateInputRequestedRegion()
+     * takes care of the case of the mask region being outside the image region. It's actually
+     * impossible to determine if the mask region is valid inside ThreadedGenerateData because
+     * outputRegionForThread is a sub region of the output region.
+     */
+  }
+
+  /* If size is zero, return */
+  const SizeValueType size0 = croppedRegion.GetSize(0);
+  if (size0 == 0)
+  {
+    return;
+  }
+
   /* Setup progress reporter */
-  ProgressReporter progress( this, threadId, outputRegionForThread.GetNumberOfPixels() );
+  ProgressReporter progress( this, threadId, croppedRegion.GetNumberOfPixels() );
 
   /* Setup iterator */
-  ImageRegionConstIteratorWithIndex< TInputImage > inputIt(inputPointer, outputRegionForThread);
+  ImageRegionConstIteratorWithIndex< TInputImage > inputIt(inputPointer, croppedRegion);
 
   /* Iterate and count */
   inputIt.GoToBegin();

--- a/include/itkKrcahEigenToScalarImageFilter.h
+++ b/include/itkKrcahEigenToScalarImageFilter.h
@@ -62,8 +62,12 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(KrcahEigenToScalarImageFilter, EigenToScalarImageFilter);
 
-  /** Mask related typedefs. */
-  typedef typename TMaskImage::PixelType    MaskPixelType;
+  /** Useful template typedefs. */
+  typedef typename TInputImage::Pointer       InputImagePointer;
+  typedef typename TInputImage::ConstPointer  InputImageConstPointer;
+  typedef typename TMaskImage::Pointer        MaskImagePointer;
+  typedef typename TMaskImage::ConstPointer   MaskImageConstPointer;
+  typedef typename TMaskImage::PixelType      MaskPixelType;
 
   /** Procesing filters */
   typedef KrcahEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >   ParameterEstimationFilterType;

--- a/include/itkKrcahEigenToScalarImageFilter.h
+++ b/include/itkKrcahEigenToScalarImageFilter.h
@@ -80,6 +80,7 @@ public:
   void SetMaskImage(const TMaskImage * mask)
   {
     this->m_ParameterEstimationFilter->SetMaskImage(mask);
+    this->Modified();
   }
   virtual const TMaskImage * GetMaskImage() const
   {
@@ -90,6 +91,7 @@ public:
   virtual void SetBackgroundValue(const MaskPixelType back)
   {
     this->m_ParameterEstimationFilter->SetBackgroundValue(back);
+    this->Modified();
   }
   virtual MaskPixelType GetBackgroundValue() const
   {
@@ -100,6 +102,7 @@ public:
   virtual void SetParameterSet(const KrcahImplementationType back)
   {
     this->m_ParameterEstimationFilter->SetParameterSet(back);
+    this->Modified();
   }
   virtual KrcahImplementationType GetParameterSet() const
   {
@@ -107,9 +110,11 @@ public:
   }
   virtual void SetParameterSetToImplementation(){
     this->m_ParameterEstimationFilter->SetParameterSetToImplementation();
+    this->Modified();
   }
   virtual void SetParameterSetToJournalArticle(){
     this->m_ParameterEstimationFilter->SetParameterSetToJournalArticle();
+    this->Modified();
   }
 
   /** Methods to get the computed parameters */
@@ -127,10 +132,12 @@ public:
   void SetEnhanceBrightObjects()
   {
     this->m_UnaryFunctorFilter->SetEnhanceBrightObjects();
+    this->Modified();
   }
   void SetEnhanceDarkObjects()
   {
     this->m_UnaryFunctorFilter->SetEnhanceDarkObjects();
+    this->Modified();
   }
   typename UnaryFunctorFilterType::RealType GetEnhanceType() const
   {

--- a/include/itkKrcahEigenToScalarImageFilter.hxx
+++ b/include/itkKrcahEigenToScalarImageFilter.hxx
@@ -63,9 +63,8 @@ void
 KrcahEigenToScalarImageFilter< TInputImage, TOutputImage, TMaskImage >
 ::GenerateData()
 {
-  /* Get input */
-  typename TInputImage::Pointer input = TInputImage::New();
-  input->Graft( const_cast< TInputImage * >( this->GetInput() ));
+  /* Get inputs */
+  InputImageConstPointer input = this->GetInput();
 
   /* Connect filters */
   m_ParameterEstimationFilter->SetInput(input);

--- a/include/itkKrcahEigenToScalarImageFilter.hxx
+++ b/include/itkKrcahEigenToScalarImageFilter.hxx
@@ -41,11 +41,16 @@ KrcahEigenToScalarImageFilter< TInputImage, TOutputImage, TMaskImage >
 ::GenerateInputRequestedRegion()
 {
   Superclass::GenerateInputRequestedRegion();
+
   if ( this->GetInput() )
   {
-  typename TInputImage::Pointer image =
-    const_cast< TInputImage * >( this->GetInput() );
-  image->SetRequestedRegionToLargestPossibleRegion();
+    InputImagePointer image = const_cast< typename Superclass::InputImageType * >( this->GetInput() );
+    image->SetRequestedRegionToLargestPossibleRegion();
+  }
+  if ( this->GetMaskImage() )
+  {
+    MaskImagePointer mask = const_cast< TMaskImage * >( this->GetMaskImage() );
+    mask->SetRequestedRegionToLargestPossibleRegion();
   }
 }
 

--- a/include/itkKrcahEigenToScalarParameterEstimationImageFilter.h
+++ b/include/itkKrcahEigenToScalarParameterEstimationImageFilter.h
@@ -65,6 +65,11 @@ namespace itk {
  * of view may throw off the parameter estimation. In those cases, a mask can
  * be provided so those voxels are not factored into the calculation of \f$ T \f$.
  * 
+ * If the input image and mask have different regions over which they
+ * are defined, parameters are estimated only in the intersection of
+ * the two image regions. However, the mask region must be a proper sub
+ * subset (contained) in the image region.
+ * 
  * \sa KrcahEigenToScalarImageFilter
  * 
  * \author: Bryce Besler

--- a/include/itkKrcahEigenToScalarParameterEstimationImageFilter.hxx
+++ b/include/itkKrcahEigenToScalarParameterEstimationImageFilter.hxx
@@ -175,11 +175,10 @@ KrcahEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
   RealType accumulatedAverageTrace = NumericTraits< RealType >::ZeroValue();
 
   /* Get input pointer */
-  InputImagePointer inputPointer = const_cast< TInputImage * >( this->GetInput() );
+  InputImageConstPointer inputPointer = this->GetInput();
 
   /* Get mask pointer */
-  MaskImagePointer maskPointer = TMaskImage::New();
-  maskPointer = const_cast<TMaskImage*>(this->GetMaskImage());
+  MaskImageConstPointer maskPointer = this->GetMaskImage();
 
   /* Setup progress reporter */
   ProgressReporter progress( this, threadId, outputRegionForThread.GetNumberOfPixels() );

--- a/include/itkKrcahEigenToScalarParameterEstimationImageFilter.hxx
+++ b/include/itkKrcahEigenToScalarParameterEstimationImageFilter.hxx
@@ -63,11 +63,16 @@ KrcahEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
 ::GenerateInputRequestedRegion()
 {
   Superclass::GenerateInputRequestedRegion();
+  
   if ( this->GetInput() )
   {
-  InputImagePointer image =
-    const_cast< typename Superclass::InputImageType * >( this->GetInput() );
-  image->SetRequestedRegionToLargestPossibleRegion();
+    InputImagePointer image = const_cast< typename Superclass::InputImageType * >( this->GetInput() );
+    image->SetRequestedRegionToLargestPossibleRegion();
+  }
+  if ( this->GetMaskImage() )
+  {
+    MaskImagePointer mask = const_cast< TMaskImage * >( this->GetMaskImage() );
+    mask->SetRequestedRegionToLargestPossibleRegion();
   }
 }
 
@@ -149,12 +154,6 @@ KrcahEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
 ::ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
                        ThreadIdType threadId)
 {
-  const SizeValueType size0 = outputRegionForThread.GetSize(0);
-  if (size0 == 0)
-  {
-    return;
-  }
-
   /* Determine which function to call */
   RealType (Self::*traceFunction)(InputPixelType);
   switch(m_ParameterSet)
@@ -180,11 +179,29 @@ KrcahEigenToScalarParameterEstimationImageFilter< TInputImage, TMaskImage >
   /* Get mask pointer */
   MaskImageConstPointer maskPointer = this->GetMaskImage();
 
+  /* If we have a mask pointer we need to crop outputRegionForThread to the mask region */
+  InputRegionType croppedRegion = outputRegionForThread;
+  if (maskPointer) {
+    croppedRegion.Crop( maskPointer->GetLargestPossibleRegion() );
+    /* No check for one region being inside the other. Superclass::GenerateInputRequestedRegion()
+     * takes care of the case of the mask region being outside the image region. It's actually
+     * impossible to determine if the mask region is valid inside ThreadedGenerateData because
+     * outputRegionForThread is a sub region of the output region.
+     */
+  }
+
+  /* If size is zero, return */
+  const SizeValueType size0 = croppedRegion.GetSize(0);
+  if (size0 == 0)
+  {
+    return;
+  }
+
   /* Setup progress reporter */
-  ProgressReporter progress( this, threadId, outputRegionForThread.GetNumberOfPixels() );
+  ProgressReporter progress( this, threadId, croppedRegion.GetNumberOfPixels() );
 
   /* Setup iterator */
-  ImageRegionConstIteratorWithIndex< TInputImage > inputIt(inputPointer, outputRegionForThread);
+  ImageRegionConstIteratorWithIndex< TInputImage > inputIt(inputPointer, croppedRegion);
 
   /* Iterate and count */
   inputIt.GoToBegin();

--- a/test/itkDescoteauxEigenToScalarParameterEstimationImageFilterTest.cxx
+++ b/test/itkDescoteauxEigenToScalarParameterEstimationImageFilterTest.cxx
@@ -146,5 +146,18 @@ int itkDescoteauxEigenToScalarParameterEstimationImageFilterTest( int, char * []
   TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( descoteauxParameterEstimator->GetBeta(), 0.5, 6, 0.000001));
   TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( descoteauxParameterEstimator->GetC(), sqrt(3)*3*0.5, 6, 0.000001));
 
+  MaskType::Pointer mask2 = MaskType::New();
+  mask2->SetRegions(maskRegion);
+  mask2->Allocate();
+  mask2->FillBuffer(foregroundValue);
+
+  descoteauxParameterEstimator->SetInput(image);
+  descoteauxParameterEstimator->SetMaskImage(mask2);
+  descoteauxParameterEstimator->SetBackgroundValue(backgroundValue);
+  TRY_EXPECT_NO_EXCEPTION(descoteauxParameterEstimator->Update());
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( descoteauxParameterEstimator->GetAlpha(), 0.5, 6, 0.000001));
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( descoteauxParameterEstimator->GetBeta(), 0.5, 6, 0.000001));
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( descoteauxParameterEstimator->GetC(), sqrt(3)*1*0.5, 6, 0.000001));
+  
   return EXIT_SUCCESS;
 }

--- a/test/itkKrcahEigenToScalarParameterEstimationImageFilterTest.cxx
+++ b/test/itkKrcahEigenToScalarParameterEstimationImageFilterTest.cxx
@@ -163,5 +163,28 @@ int itkKrcahEigenToScalarParameterEstimationImageFilterTest( int, char * [] )
   TEST_EXPECT_EQUAL(krcahParameterEstimator->GetGamma(), -3*1*0.25);
   TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( krcahParameterEstimator->GetGamma(), -3*1*0.25, 6, 0.000001));
 
+  MaskType::Pointer mask2 = MaskType::New();
+  mask2->SetRegions(maskRegion);
+  mask2->Allocate();
+  mask2->FillBuffer(foregroundValue);
+
+  krcahParameterEstimator->SetInput(image);
+  krcahParameterEstimator->SetParameterSetToImplementation();
+  krcahParameterEstimator->SetMaskImage(mask2);
+  krcahParameterEstimator->SetBackgroundValue(backgroundValue);
+  TRY_EXPECT_NO_EXCEPTION(krcahParameterEstimator->Update());
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( krcahParameterEstimator->GetAlpha(), itk::Math::sqrt2 * 0.5, 6, 0.000001));
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( krcahParameterEstimator->GetBeta(), itk::Math::sqrt2 * 0.5, 6, 0.000001));
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( krcahParameterEstimator->GetGamma(), itk::Math::sqrt2 * 3*1*0.5, 6, 0.000001));
+
+  krcahParameterEstimator->SetInput(image);
+  krcahParameterEstimator->SetParameterSetToJournalArticle();
+  krcahParameterEstimator->SetMaskImage(mask2);
+  krcahParameterEstimator->SetBackgroundValue(backgroundValue);
+  TRY_EXPECT_NO_EXCEPTION(krcahParameterEstimator->Update());
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( krcahParameterEstimator->GetAlpha(), 0.5, 6, 0.000001));
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( krcahParameterEstimator->GetBeta(), 0.5, 6, 0.000001));
+  TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual( krcahParameterEstimator->GetGamma(), -3*1*0.25, 6, 0.000001));
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This resolves #4. I do not explicitly handle the case of the mask being larger than the input image. Instead, if the mask is bigger there will be an error on `Update()`. In the `ThreadedGenerateDataMethod`, a image region crop is performed to compute the intersection of this threads region and the mask region. This should speed up computation.

I also corrected two other bugs. First, I removed inappropriate `const_cast`.  Next, I added `Modified()` to the setters of `KrcahEigenToScalarImageFilter`.