### PR TITLE
COMP: Remove deprecated throw specification

### DIFF
--- a/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.h
+++ b/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.h
@@ -103,8 +103,8 @@ public:
    * provide an implementation for GenerateInputRequestedRegion() in
    * order to inform the pipeline execution model.
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
-  virtual void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError );
-  
+  virtual void GenerateInputRequestedRegion();
+
 #ifdef ITK_USE_CONCEPT_CHECKING
   // Begin concept checking
   itkConceptMacro( InputOutputHaveSamePixelDimensionCheck,

--- a/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.hxx
+++ b/include/itkKrcahEigenToScalarPreprocessingImageToImageFilter.hxx
@@ -46,7 +46,6 @@ template< typename TInputImage, typename TOutputImage >
 void
 KrcahEigenToScalarPreprocessingImageToImageFilter< TInputImage, TOutputImage >
 ::GenerateInputRequestedRegion()
-throw( InvalidRequestedRegionError )
 {
   // This implementation is copied from itkDiscreteGaussianImageFilter
 


### PR DESCRIPTION
```
 warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
 throw( InvalidRequestedRegionError )
```